### PR TITLE
Generate issue page in rock design

### DIFF
--- a/page.rb
+++ b/page.rb
@@ -1,0 +1,13 @@
+require 'erb'
+
+class Page
+  def initialize(vars)
+    @vars = vars
+  end
+
+  def render(path)
+    content = File.read(File.expand_path(path))
+    renderer = ERB.new(content)
+    renderer.result(binding)
+  end
+end

--- a/template/default.html.erb
+++ b/template/default.html.erb
@@ -1,0 +1,97 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=iso-8859-1" />
+  <meta name="description" content="The Robot Construction Kit - a robot software development environment" />
+  <meta name="keywords" content="robotics,toolchain,components,field robotics,underwater robotics" />
+  <meta name="author" content="The Rock core team" />
+  <title><%= @vars[:title] %></title>
+   <script type="text/javascript" language="javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
+   <link rel="stylesheet" href="http://rock-robotics.org/stable/style_screen.css" type="text/css" />
+   <meta http-equiv="x-dns-prefetch-control" content="off"/>
+</head>
+
+<body>
+  <div class="page-container-2">
+      <div class="nav1-container">
+          <div class="nav1">
+          </div>
+          <div class="search">
+              <div id="cse-search-form" style="width: 100%;">Loading</div>
+              <script src="http://www.google.com/jsapi" type="text/javascript"></script>
+              <script type="text/javascript">
+                google.load('search', '1', {language : 'en'});
+                google.setOnLoadCallback(function() {
+                  var customSearchControl = new
+              google.search.CustomSearchControl('008757635177184297913:WMX139135563');
+                  customSearchControl.setResultSetSize(google.search.Search.LARGE_RESULTSET);
+                  var options = new google.search.DrawOptions();
+                  options.enableSearchboxOnly("<%= @vars[:base_path] %>/search_results.html");
+                  customSearchControl.draw('cse-search-form', options);
+                }, true);
+              </script>
+              <link rel="stylesheet" href="http://www.google.com/cse/style/look/default.css"
+              type="text/css" />
+              <style type="text/css">
+                input.gsc-input {
+                  border-color: #BCCDF0;
+                }
+                input.gsc-search-button {
+                  border-color: #CECECE;
+                  background-color: #E9E9E9;
+                }
+              </style>
+          </div>
+      </div>
+
+      <div class="site-name" onclick="location.href='<%= @vars[:base_path] %>';" style="cursor: pointer; z-index: 10;">
+          <p class="title">Rock</p>
+          <p class="subtitle">the Robot Construction Kit</p>
+      </div>
+
+      <div class="title_buffer"></div>
+
+      <div class="nav2">
+          <ul>
+            <li><%= render "template/#{@vars[:page]}_breadcrumb.html.erb" %><span class="empty">&nbsp;</span></li>
+          </ul>
+      </div>
+
+      <div class="buffer">
+          <div class="flavor_nav">
+          </div>
+      </div>
+
+      <div class="leftnav">
+        <%= render "template/#{@vars[:page]}_navigation.html.erb" %>
+      </div>
+
+
+      <div class="content2">
+          <div class="content2-pagetitle"><%= @vars[:heading] %></div>
+          <div class="content2-container line-box">
+              <div class="content2-container-1col">
+                <%= render "template/#{@vars[:page]}_content.html.erb" %>
+              </div>
+          </div>
+          This page got updated at <%= Time.now %>
+      </div>
+
+      <!-- FOOTER -->
+      <div class="footer">
+        <div><p style="text-align:center;"><a href="<%= @vars[:base_path] %>/impressum.html">Imprint/Impressum</a></div></p>
+        <div class="nav1">
+          <ul>
+            <li><a href="<%= @vars[:base_path] %>/documentation/about/index.html">About Rock</a></li>
+          </ul>
+        </div>
+      </div>
+  </div>
+</body>
+</html>
+
+<!--
+vim:tw=0:ft=eruby
+-->
+

--- a/template/issues_breadcrumb.html.erb
+++ b/template/issues_breadcrumb.html.erb
@@ -1,0 +1,1 @@
+<a href="<%= @vars[:base_path] %>/status">Status</a><span>Issues</span>

--- a/template/issues_content.html.erb
+++ b/template/issues_content.html.erb
@@ -1,0 +1,11 @@
+<% @vars[:issues].each do |name, iss| %>
+  <% if iss.size > 0 %>
+    <% pr_cnt = 0; iss.each { |is| pr_cnt = pr_cnt +1 if  is['html_url'].include? "pull" } %>
+    <h2 id="<%= name %>"><a href="http://github.com/<%= name %>">Package</a> <%= name %> has <%= iss.size %> <a href="http://github.com/<%= name %>/issues?q=is%3Aopen">issues</a> from this <%= pr_cnt %> are <a href="http://github.com/<%= name %>/pulls?q=is%3Aopen">Pull-Requests</a></h2>
+    <ul>
+    <% iss.each do |is| %>
+      <li><a href="<%= is['html_url'] %>"><%= if is['html_url'].include? "pull" then "Pull-Request" else "Issue" end %> <%= is['number'] %></a> <%= is['title'] %></li>
+    <% end %>
+    </ul>
+  <% end %>
+<% end %>

--- a/template/issues_navigation.html.erb
+++ b/template/issues_navigation.html.erb
@@ -1,0 +1,23 @@
+<div class="nav3">
+  <%
+    orgs = {}
+    @vars[:issues].each do |name, iss|
+      org_name = name.split("/")[0]
+      orgs[org_name] = {} unless orgs[org_name]
+      orgs[org_name][name] = iss
+    end
+    orgs.each do |org, issues|
+      org_issues = issues.map { |_, iss| iss.size }.inject(:+)
+      if org_issues > 0
+  %>
+        <div class="title"><%= org %></div>
+        <ul>
+          <% issues.each do |name, iss| %>
+            <% if iss.size > 0 %>
+              <li><a href="#<%= name %>"><%= name.split("/")[1] %></a></li>
+            <% end %>
+          <% end %>
+        </ul>
+      <% end %>
+    <% end %>
+</div>


### PR DESCRIPTION
The screenshot explains it best, I guess.

![rock_issues_pr](https://cloud.githubusercontent.com/assets/2951180/8232995/ed471798-15d3-11e5-8357-1f73cc8c8325.png)

The navigation on the left links directly to the issues of a repo. Only repos and organisations with issues are listed.
